### PR TITLE
feat: Add GitHub issue creation via MCP

### DIFF
--- a/front-end/components/tasks/steps/step5-allocation.tsx
+++ b/front-end/components/tasks/steps/step5-allocation.tsx
@@ -7,18 +7,21 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
-import { IconCheck, IconAlertCircle } from "@tabler/icons-react"
+import { IconCheck, IconAlertCircle, IconLoader } from "@tabler/icons-react"
 import { motion } from "motion/react"
 import { useState } from "react"
+import { Button } from "@/components/ui/button"
 
 interface Step5AllocationProps {
   state: TaskCreationState
   updateState: (updates: Partial<TaskCreationState>) => void
+  onCreateTask?: () => Promise<void>
+  isCreating?: boolean
 }
 
-export function Step5Allocation({ state, updateState }: Step5AllocationProps) {
+export function Step5Allocation({ state, updateState, onCreateTask, isCreating }: Step5AllocationProps) {
   const [createGitHubIssues, setCreateGitHubIssues] = useState(true)
-  const [repository, setRepository] = useState("example/repo")
+  const [repository, setRepository] = useState("salmanmkc/agentverse")
   const [projectBoard, setProjectBoard] = useState("")
   const [sendNotifications, setSendNotifications] = useState(true)
 
@@ -209,11 +212,30 @@ export function Step5Allocation({ state, updateState }: Step5AllocationProps) {
 
       <div className="rounded-lg border bg-muted/30 p-4">
         <h4 className="font-medium mb-2">Ready to create?</h4>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-muted-foreground mb-4">
           Click "Create Task" to finalize. The task will be added to your
           dashboard{createGitHubIssues && ", GitHub issues will be created"}
           {sendNotifications && ", and team members will be notified"}.
         </p>
+        
+        <Button 
+          onClick={onCreateTask}
+          disabled={isCreating || !onCreateTask}
+          size="lg"
+          className="w-full gap-2"
+        >
+          {isCreating ? (
+            <>
+              <IconLoader className="size-5 animate-spin" />
+              Creating Task & Issues...
+            </>
+          ) : (
+            <>
+              <IconCheck className="size-5" />
+              Create Task
+            </>
+          )}
+        </Button>
       </div>
     </div>
   )

--- a/front-end/types/api.ts
+++ b/front-end/types/api.ts
@@ -35,9 +35,13 @@ export interface FindMatchesResponse {
 
 export interface CreateGitHubIssuesRequest {
   taskTitle: string
+  taskDescription?: string
   subtasks: Array<{
     subtaskId: string
-    assignedUserId: string
+    subtaskTitle: string
+    subtaskDescription: string
+    assignedUserId: string // GitHub username from User.id
+    estimatedHours?: number
   }>
   repository?: string
   projectBoard?: string

--- a/mcp-backend/charts/ai-platform-engineering/data/prompt_config.yaml
+++ b/mcp-backend/charts/ai-platform-engineering/data/prompt_config.yaml
@@ -183,7 +183,13 @@ agent_prompts:
       If the user's prompt is related to Confluence operations, such as creating a new Confluence page, updating an existing page, retrieving the content of a page, or searching for pages, assign the task to the Confluence agent.
   github:
     system_prompt: |
-      If the user's prompt is related to GitHub operations, such as creating a new repository, listing open pull requests, merging a pull request, closing an issue, or getting the latest commit, assign the task to the GitHub agent.
+      If the user's prompt is related to GitHub operations, such as creating issues, creating a new repository, listing open pull requests, merging a pull request, closing an issue, assigning issues to users, or getting the latest commit, assign the task to the GitHub agent.
+      
+      When creating GitHub issues:
+      1. Use the GitHub MCP create_issue tool for EACH issue
+      2. Set the title, body (description + estimated hours), assignee, and labels
+      3. Return the created issue URLs in JSON format:
+      {"issueUrls": ["https://github.com/owner/repo/issues/123", ...]}
   jira:
     system_prompt: |
       If the user's prompt is related to Jira operations, such as creating a new Jira ticket, listing open tickets, updating the status of a ticket, assigning a ticket to a user, getting details of a ticket, or searching for tickets, assign the task to the Jira agent.

--- a/mcp-backend/docker-compose.yaml
+++ b/mcp-backend/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
     # Each agent is marked with 'required: false', so platform-engineer will start even if the agent is missing.
     # 'condition: service_started' means Docker Compose will wait until the service has started (not necessarily healthy) before starting platform-engineer.
     depends_on:
-      # - agent-github-p2p
+      - agent-github-p2p
       - agent_rag
       - agent-slack-p2p
       - agent-weather-p2p
@@ -31,7 +31,7 @@ services:
       - A2A_TRANSPORT=p2p # Use A2A protocol for agent-to-agent communication.
 
       # Agent hosts
-      # - GITHUB_AGENT_HOST=agent-github-p2p
+      - GITHUB_AGENT_HOST=agent-github-p2p
       - SLACK_AGENT_HOST=agent-slack-p2p
       - WEATHER_AGENT_HOST=agent-weather-p2p
       - WEBEX_AGENT_HOST=agent-webex-p2p
@@ -58,24 +58,24 @@ services:
   ####################################################################################################
   #                                      AGENT GITHUB A2A P2P                                        #
   # ####################################################################################################
-  # agent-github-p2p:
-  #   image: ghcr.io/cnoe-io/agent-github:0.2.0
-  #   container_name: agent-github-p2p
-  #   profiles:
-  #     - p2p
-  #     - p2p-tracing
-  #   volumes:
-  #     - /var/run/docker.sock:/var/run/docker.sock
-  #   env_file:
-  #     - .env
-  #   ports:
-  #     - "8007:8000"
-  #   environment:
-  #     - A2A_TRANSPORT=p2p
-  #     - MCP_MODE=${MCP_MODE:-http}
-  #     - ENABLE_TRACING=${ENABLE_TRACING:-false}
-  #     - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-  #     - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
+  agent-github-p2p:
+    image: ghcr.io/cnoe-io/agent-github:0.2.0
+    container_name: agent-github-p2p
+    profiles:
+      - p2p
+      - p2p-tracing
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    env_file:
+      - .env
+    ports:
+      - "8007:8000"
+    environment:
+      - A2A_TRANSPORT=p2p
+      - MCP_MODE=${MCP_MODE:-http}
+      - ENABLE_TRACING=${ENABLE_TRACING:-false}
+      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
+      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
 
   ####################################################################################################
   #                                      AGENT SLACK A2A P2P                                         #


### PR DESCRIPTION
Implements automated GitHub issue creation using AI prompts and Model Context Protocol (MCP).

Changes:
- Add Create Task button in Step 5 with loading states
- Implement aiService.createGitHubIssues with streaming response parsing
- Configure GitHub repository input (defaults to salmanmkc/agentverse)
- Map task allocations to GitHub issue assignments using User.id
- Add proper error handling and toast notifications
- Update TypeScript types for CreateGitHubIssuesRequest

How it works:
1. User completes task creation flow through Steps 1-4
2. On Step 5, toggle Create GitHub Issues and enter repository
3. Click Create Task button
4. Frontend sends prompt to AI backend at http://localhost:8000
5. Backend uses GitHub MCP tools to create issues and assign to team members
6. Success toast shows number of issues created